### PR TITLE
Update TOC interface versions for Midnight (12.0.1)

### DIFF
--- a/ImprovedLootFrame.toc
+++ b/ImprovedLootFrame.toc
@@ -1,6 +1,6 @@
-﻿## Interface: 110002
-## Interface-Classic: 11503
-## Interface-Cata: 40400
+﻿## Interface: 120001
+## Interface-Classic: 11508
+## Interface-Cata: 40402
 ## Title: Improved Loot Frame
 ## Version: 4.0.1
 ## Author: Cybeloras of Aerie Peak

--- a/ImprovedLootFrame.toc
+++ b/ImprovedLootFrame.toc
@@ -2,7 +2,7 @@
 ## Interface-Classic: 11508
 ## Interface-Cata: 40402
 ## Title: Improved Loot Frame
-## Version: 4.0.1
+## Version: 4.0.2
 ## Author: Cybeloras of Aerie Peak
 ## Notes: Expands the loot frame to fit all items onto one page.
 ## X-Curse-Project-ID: 30888


### PR DESCRIPTION
## Summary

- Retail: `110002` → `120001` (Midnight 12.0.1)
- Classic Era: `11503` → `11508` (1.15.8)
- Cata Classic: `40400` → `40402` (4.4.2)

## Details

No Lua code changes needed. The addon's two code paths both use stable APIs:

- **Retail** (line 116): `LootFrame.panelMaxHeight = UIParent:GetHeight() * .7` — unchanged in 12.x
- **Classic** (lines 11–114): `LootButton` expansion via `LootFrame_Show` hook — unchanged in current Classic clients

This is a TOC-only version bump to remove the "out of date" addon warning.